### PR TITLE
CSV出力する際に、"NameError (uninitialized constant EstimateTimelogHelper::Icon...

### DIFF
--- a/app/helpers/estimate_timelog_helper.rb
+++ b/app/helpers/estimate_timelog_helper.rb
@@ -15,6 +15,8 @@
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+require 'iconv'
+
 module EstimateTimelogHelper
   include ApplicationHelper
 


### PR DESCRIPTION
CSV出力しようとすると、NameErrorが出てダウンロードできなかったので修正しました
当方のRubyバージョン1.9.3p545
